### PR TITLE
feat: introduce module parameters support

### DIFF
--- a/examples/probe.rs
+++ b/examples/probe.rs
@@ -1,7 +1,7 @@
 use rkmod::cache::InternCache;
 use rkmod::controller::SystemModuleController;
 use rkmod::database::directory::ModuleDirectory;
-use rkmod::manager::ModuleManager;
+use rkmod::manager::{ModuleManager, ModuleParameterSet};
 use rkmod::util::normalize_module_name;
 use std::sync::Arc;
 
@@ -14,6 +14,7 @@ fn main() {
 
     let directory =
         ModuleDirectory::current(cache.clone()).expect("failed to load module directory");
-    let manager = ModuleManager::new(directory, SystemModuleController::default());
+    let parameters = ModuleParameterSet::new();
+    let manager = ModuleManager::new(directory, SystemModuleController::default(), parameters);
     manager.probe(&modules).expect("failed to probe modules");
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("nix error: {0}")]
     #[cfg(feature = "module-manager")]
     NixError(#[from] nix::errno::Errno),
+    #[error("c string conversion error: {0}")]
+    #[cfg(feature = "module-manager")]
+    NulError(std::ffi::NulError),
     #[error("dependency loop found on {0}")]
     DependencyLoop(Arc<String>),
     #[error("dependency missing: {0}")]


### PR DESCRIPTION
Introduce support for module manager to have a module parameter set.

The basic idea is that something external to rkmod glues together all of the configured parameters of a module and inserts it into the parameter set, and then passes it to ModuleManager which handles providing parameters during probing.