### PR TITLE
fix: harden module parsers against malformed input

### DIFF
--- a/src/object/content.rs
+++ b/src/object/content.rs
@@ -44,6 +44,11 @@ impl KernelObjectContent {
             return false;
         }
 
+        // Need at least the e_ident fields read below (EI_CLASS, EI_DATA, EI_VERSION).
+        if self.bytes.len() < 7 {
+            return false;
+        }
+
         // Byte 5: EI_CLASS, 0x1 = 32-bit, 0x2 = 64-bit module
         if self.bytes[4] != 1 && self.bytes[4] != 2 {
             return false;

--- a/src/signature/raw.rs
+++ b/src/signature/raw.rs
@@ -67,8 +67,10 @@ impl RawKernelObjectSignature {
         let header = bytemuck::try_pod_read_unaligned::<RawKernelObjectSignatureHeader>(header)
             .map_err(Error::DataDecodeError)?;
         let signature_length = header.signature_length() as usize;
-        let total_length =
-            signature_length + header.signer_length as usize + header.key_id_length as usize;
+        let total_length = signature_length
+            + header.signer_length as usize
+            + header.key_id_length as usize
+            + size_of::<RawKernelObjectSignatureHeader>();
         if signature_length == 0 || (total_length > before_magic.len()) {
             return Ok(Some(RawKernelObjectSignature {
                 header,


### PR DESCRIPTION
Fixes two panics when parsing untrusted/malformed module files:

- **Signature parsing** (`src/signature/raw.rs`): the bounds check omitted the header size, so a crafted signature length could pass validation and underflow the slice offsets.
- **ELF detection** (`src/object/content.rs`): `check_elf` read bytes 4-6 after only verifying the 4-byte magic, panicking on files shorter than 7 bytes.